### PR TITLE
feat: replacing id/secret authentication with personal token

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ git clone https://github.com/aziontech/cells-site-template
 ## Build
 
 You will need a bucket in AWS S3, its access key and its secret access key. You can set the credentials at the `azion.json` file inside the project or define the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. The access credentials to the bucket will be stored in the code sent to Azion and the Edge Function will use them to retrieve the necessary pages stored during the publish step.
-Similarly, you will need credentials to deploy your project at Azion and you can either set those in the `azion.json` file or define the environment variables `AZION_ID` and `AZION_SECRET`. The Azion credentials are not stored in the built code.
+Similarly, you will need credentials to deploy your project at Azion and you can either set those in the `azion.json` file or define the environment variable `AZION_TOKEN`. The Azion credentials are not stored in the built code.
 
 ### Build steps
 ```
@@ -56,8 +56,7 @@ Similarly, you will need credentials to deploy your project at Azion and you can
       "path": "__static_content"
     },
     "azion": {
-      "id": "<AZION_ID>",
-      "secret": "<AZION_SECRET>",
+      "token": "<AZION_TOKEN>",
       "function_name": "my-function-name"
     }
   }

--- a/azion.json
+++ b/azion.json
@@ -7,8 +7,7 @@
     "path": "__static_content"
   },
   "azion": {
-    "id": "user@azion.com",
-    "secret": "password",
+    "token": "my-personal-token",
     "function_name": "my-function-name",
     "end_point": "https://stage-api.azion.net"
   },

--- a/src/azion-api.ts
+++ b/src/azion-api.ts
@@ -48,7 +48,7 @@ export class AzionApi {
             const response: AxiosResponse<ObjectAPIResult> = await axios({
                 url: `${this.url}/edge_functions`,
                 method: 'POST',
-                headers: apiBaseHeaders(await this.token),
+                headers: apiBaseHeaders(this.token),
                 data: edgeFunction,
             });
             return response.data.results;

--- a/src/azion-api.ts
+++ b/src/azion-api.ts
@@ -39,26 +39,8 @@ export class AzionApi {
         this.token = token;
     }
 
-    static async init(url: string = DEFAULT_API_URL, user: string, password: string): Promise<AzionApi> {
-        const token = await this.getToken(url, user, password);
+    static async init(url: string = DEFAULT_API_URL, token: string): Promise<AzionApi> {
         return new AzionApi( url, token );
-    }
-
-    private static async getToken(url: string, user: string, password: string): Promise<string> {
-        const credentialsBase64 = Buffer.from(`${user}:${password}`).toString('base64');
-        try {
-            const response = await axios({
-                url: `${url}/tokens`,
-                method: 'POST',
-                headers: {
-                    'Accept': 'application/json; version=3',
-                    'Authorization': 'Basic ' + credentialsBase64
-                }
-            });
-            return response.data.token;
-        } catch (err: any) {
-            throw new CannotSaveFunction(JSON.stringify(err.response?.data));
-        }
     }
 
     async saveFunction(edgeFunction: EdgeFunction): Promise<EdgeFunction> {

--- a/src/azion-publisher-config.schema.json
+++ b/src/azion-publisher-config.schema.json
@@ -17,10 +17,9 @@
             "required": [
                 "function_name"
             ],
-            "$comment": "id and secrete aren't required if user sets environment variables AZION_ID and AZION_SECRET.",
+            "$comment": "token is not required if user sets environment variable AZION_TOKEN.",
             "properties": {
-                "id": "string",
-                "secret": "string",
+                "token": "string",
                 "function_name": "string",
                 "end_point": "string"
             }

--- a/src/azion-publisher.ts
+++ b/src/azion-publisher.ts
@@ -28,9 +28,8 @@ export class AzionPublisher {
         const config = await validate(cfg, AzionPublisherConfigSchema,
             'https://azion.com/azion-framework-adapter/2022-05.1/azion-publisher.schema.json');
         const azion = config.azion;
-        azion.id = azion.id ?? env.AZION_ID;
-        azion.secret = azion.secret ?? env.AZION_SECRET;
-        if (!azion.id || !azion.secret) {
+        azion.token = azion.token ?? env.AZION_TOKEN;
+        if (!azion.token) {
             throw new AzionCredentialsNotSet();
         }
         return config;

--- a/src/azion-publisher.ts
+++ b/src/azion-publisher.ts
@@ -7,8 +7,7 @@ import { validate } from './config';
 import { AzionCredentialsNotSet } from './errors';
 
 export interface AzionConfig {
-    id: string,
-    secret: string,
+    token: string,
     function_name: string,
     end_point?: string
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,8 +11,7 @@ export interface KVConfig {
 }
 
 export interface AzionConfig {
-    id: string,
-    secret: string,
+    token: string,
     function_name: string,
     end_point?: string
 }

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -24,7 +24,7 @@ export async function publish(options: any): Promise<ErrorCode> {
 
         if (!options.onlyAssets) {
             const cfg: AzionPublisherConfig = await AzionPublisher.getConfig(rawCfg, process.env);
-            const azion = await AzionApi.init(cfg.azion.end_point, cfg.azion.id, cfg.azion.secret);
+            const azion = await AzionApi.init(cfg.azion.end_point, cfg.azion.token);
             const publisher = new AzionPublisher(azion, cwd(), cfg);
             await publisher.deployEdgeFunction();
         }

--- a/test/ts/asset-publisher.test.ts
+++ b/test/ts/asset-publisher.test.ts
@@ -112,8 +112,7 @@ describe('Asset Publisher', () => {
     it('should accept additional config parameters', async () => {
         const rawCfg: any = {
             azion: {
-                id: "6",
-                secret: "7",
+                token: "azion-personal-token",
                 function_name: "MyFunctionName"
             },
             kv: {

--- a/test/ts/azion-api.test.ts
+++ b/test/ts/azion-api.test.ts
@@ -19,35 +19,13 @@ function getEdgeFunctionData(): EdgeFunction {
 describe('azion-api', async () => {
     const axiosMock = new MockAdapter(axios);
     const azionApiUrl = "http://azion.api.domain";
-    const user = 'user.name@domain.com';
-    const password = 'password';
+    const token = 'azion-personal-token'
 
     afterEach(() => axiosMock.reset());
-
-    it('should fetch token api', async () => {
-        axiosMock.onPost(`${azionApiUrl}/tokens`)
-            .reply((config) => {
-                expect(config.headers).to.have.property('Authorization');
-                expect(config.headers).to.own.include({ 'Accept': 'application/json; version=3' });
-                return [201, { token: '#token#' }];
-            });
-
-        const azionApi = AzionApi.init(azionApiUrl, user, password);
-        return azionApi.should.be.fulfilled;
-    });
-
-    it('should fail on fetching token', async () => {
-        axiosMock.onPost(`${azionApiUrl}/tokens`)
-            .reply(401);
-
-        const azionApi = AzionApi.init(azionApiUrl, user, password);
-        return azionApi.should.be.rejected;
-    });
 
     it('should save an edge function', async () => {
         const edgeFunction = getEdgeFunctionData();
 
-        axiosMock.onPost(`${azionApiUrl}/tokens`).reply(201, { token: '#token#' });
         axiosMock.onPost(`${azionApiUrl}/edge_functions`)
             .reply((config) => {
                 expect(config.headers).to.have.property('Authorization');
@@ -60,7 +38,7 @@ describe('azion-api', async () => {
                 }];
             });
 
-        const azionApi = await AzionApi.init(azionApiUrl, user, password);
+        const azionApi = await AzionApi.init(azionApiUrl, token);
         const savedEdgeFunction = azionApi.saveFunction(edgeFunction);
 
         return savedEdgeFunction.should.eventually.to.include({ id: 1 })
@@ -71,7 +49,6 @@ describe('azion-api', async () => {
         const edgeFunction = getEdgeFunctionData();
         edgeFunction.id = 1;
 
-        axiosMock.onPost(`${azionApiUrl}/tokens`).reply(201, { token: '#token#' });
         axiosMock.onPost(`${azionApiUrl}/edge_functions`).reply(400);
         axiosMock.onGet(`${azionApiUrl}/edge_functions`)
             .reply(200, {
@@ -81,7 +58,7 @@ describe('azion-api', async () => {
         axiosMock.onPatch(`${azionApiUrl}/edge_functions/${edgeFunction.id}`)
             .reply(200, { results: { edgeFunction } });
 
-        const azionApi = await AzionApi.init(azionApiUrl, user, password);
+        const azionApi = await AzionApi.init(azionApiUrl, token);
         const savedEdgeFunction = azionApi.saveFunction(edgeFunction);
 
         return savedEdgeFunction.should.be.fulfilled
@@ -91,11 +68,10 @@ describe('azion-api', async () => {
     it('should fail on saving edge function', async () => {
         const edgeFunction = getEdgeFunctionData();
 
-        axiosMock.onPost(`${azionApiUrl}/tokens`).reply(201, { token: '#token#' });
         axiosMock.onAny(`${azionApiUrl}/edge_functions`)
             .reply(400);
 
-        const azionApi = await AzionApi.init(azionApiUrl, user, password);
+        const azionApi = await AzionApi.init(azionApiUrl, token);
         const createdEdgeFunction = azionApi.saveFunction(edgeFunction);
         return createdEdgeFunction.should.be.rejected;
     });

--- a/test/ts/azion-api.test.ts
+++ b/test/ts/azion-api.test.ts
@@ -42,7 +42,7 @@ describe('azion-api', async () => {
         const savedEdgeFunction = azionApi.saveFunction(edgeFunction);
 
         return savedEdgeFunction.should.eventually.to.include({ id: 1 })
-            .then(() => expect(axiosMock.history.post).to.have.lengthOf(2));
+            .then(() => expect(axiosMock.history.post).to.have.lengthOf(1));
     });
 
     it('should update an edge function if it exists', async () => {

--- a/test/ts/azion-publisher.test.ts
+++ b/test/ts/azion-publisher.test.ts
@@ -103,8 +103,7 @@ describe('Azion Publisher', () => {
     it('publish to Azion', async () => {
         const rawCfg: Config = {
             azion: {
-                id: "6",
-                secret: "7",
+                token: "azion-personal-token",
                 function_name: "MyFunctionName"
             }
         };
@@ -128,8 +127,7 @@ describe('Azion Publisher', () => {
     it('accepts additional config parameters', async () => {
         const rawCfg: any = {
             azion: {
-                id: "6",
-                secret: "7",
+                token: "azion-personal-token",
                 function_name: "MyFunctionName"
             },
             kv: {

--- a/test/ts/configuration.test.ts
+++ b/test/ts/configuration.test.ts
@@ -38,8 +38,7 @@ describe('config', () => {
                     path: "val5"
                 },
                 azion: {
-                    id: 'val6',
-                    secret: 'val7',
+                    token: "azion-personal-token",
                     function_name: 'val8'
                 }
             };


### PR DESCRIPTION
The need to use Tokens arose during the development of the [Azion Edge Functions extension for VSCode](https://github.com/aziontech/azion-edge-functions-vscode-extension). Currently the package uses user _id and password_ to generate a _token_ via API and authenticate the user. Recently, Azion created the personal token (with expiration date) feature.

### Pros:
- It's easier to use
- Is safer
- Reduces one step (POST request to generate base64 token)