### PR TITLE
feat: feedback with published function id

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -173,7 +173,7 @@ export class Builder {
             const cfg = await AssetPublisher.getConfig(rawCfg, process.env);
             const kvArgs: KVArgs = Object.assign({ retries: 0 }, cfg.kv);
 
-            const builder = await Builder.init();
+            const builder = Builder.init();
 
             let webpackConfigPath = BASIC_CFG_PATH;
             if (!options.staticSite) {

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -26,7 +26,8 @@ export async function publish(options: any): Promise<ErrorCode> {
             const cfg: AzionPublisherConfig = await AzionPublisher.getConfig(rawCfg, process.env);
             const azion = await AzionApi.init(cfg.azion.end_point, cfg.azion.token);
             const publisher = new AzionPublisher(azion, cwd(), cfg);
-            await publisher.deployEdgeFunction();
+            const deployedEdgeFunction = await publisher.deployEdgeFunction();
+            console.log('Function id:', deployedEdgeFunction.id);
         }
 
         return ErrorCode.Ok;


### PR DESCRIPTION
To use the adapter in [Azion Edge Functions extension for VSCode](https://github.com/aziontech/azion-edge-functions-vscode-extension) i need the publisher to have an output with the _id of the published function_ (so that it is possible to perform all the platform configurations without an extra request).

This will be useful for other uses of the Adapter.


**Note: The console output string can be rethought (Function id: $id)**