### PR TITLE
Add a short alias to the executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .nyc_output
 coverage
 test-results
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.2.0",
   "description": "Command line tool that builds Jamstack projects targeting Azion's Edge Functions.",
   "main": "dist/main.js",
-  "bin": "dist/main.js",
+  "bin": {
+    "azion-framework-adapter": "dist/main.js",
+    "azfa": "dist/main.js"
+  },
   "scripts": {
     "build": "tsc --build --verbose && copyfiles --up 1 src/libs/**/* ./dist",
     "build:all": "npm i && npm run build && npm i --package-lock",


### PR DESCRIPTION
Add azfa alias. Now users can run `azion-framework-adapter` or `azfa` to run the cli.