### PR TITLE
Bump azfa version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-framework-adapter",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Command line tool that builds Jamstack projects targeting Azion's Edge Functions.",
   "main": "dist/main.js",
   "bin": {


### PR DESCRIPTION
- v0.2.2 has been unpublished in npm and cannot be republished.