### PR TITLE
remove filemanager-webpack-puglin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azion-framework-adapter",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azion-framework-adapter",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.1031.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "aws-sdk": "^2.1031.0",
     "axios": "^0.24.0",
     "commander": "^8.3.0",
-    "filemanager-webpack-plugin": "^3",
     "jsonpolice": "^8.2.2",
     "simple-git": "^3.15.0",
     "ts-results": "^3.3.0",

--- a/src/build.ts
+++ b/src/build.ts
@@ -121,9 +121,8 @@ export class Builder {
         workerCompiler.hooks.beforeRun.tapAsync(
             "Before compile",
             (_, callback) => {
-                isStaticSite
-                    ? fs.copyFileSync("./src/index.js", "./src/index.tmp.js")
-                    : fs.copyFileSync("./index.js", "./index.tmp.js");
+
+                fs.copyFileSync(isStaticSite? "./src/index.js": "./index.js", config.entry);
 
                 const bootstrapUtils = new BootstrapUtils(
                     config.entry?.toString() ?? "./index.tmp.js",
@@ -137,9 +136,7 @@ export class Builder {
         workerCompiler.hooks.done.tapAsync(
             "After compile",
             (_, callback) => {
-                isStaticSite
-                    ? fs.rmSync("./src/index.tmp.js")
-                    : fs.rmSync("./index.tmp.js");
+                fs.rmSync(config.entry);
                 callback();
             }
         );

--- a/src/build.ts
+++ b/src/build.ts
@@ -119,13 +119,27 @@ export class Builder {
         if (isStaticSite) bootstrapCode += ' global.__PROJECT_TYPE_PATTERN = PROJECT_TYPE_PATTERN_VALUE;';
 
         workerCompiler.hooks.beforeRun.tapAsync(
-            "FileManagerPlugin",
+            "Before compile",
             (_, callback) => {
+                isStaticSite
+                    ? fs.copyFileSync("./src/index.js", "./src/index.tmp.js")
+                    : fs.copyFileSync("./index.js", "./index.tmp.js");
+
                 const bootstrapUtils = new BootstrapUtils(
                     config.entry?.toString() ?? "./index.tmp.js",
                     bootstrapCode
                 );
                 bootstrapUtils.addBootstrap();
+                callback();
+            }
+        );
+
+        workerCompiler.hooks.afterCompile.tapAsync(
+            "After compile",
+            (_, callback) => {
+                isStaticSite
+                    ? fs.rmSync("./src/index.tmp.js")
+                    : fs.rmSync("./index.tmp.js");
                 callback();
             }
         );

--- a/src/build.ts
+++ b/src/build.ts
@@ -134,7 +134,7 @@ export class Builder {
             }
         );
 
-        workerCompiler.hooks.afterCompile.tapAsync(
+        workerCompiler.hooks.done.tapAsync(
             "After compile",
             (_, callback) => {
                 isStaticSite

--- a/src/configs/flareact/webpack.worker.config.ts
+++ b/src/configs/flareact/webpack.worker.config.ts
@@ -1,8 +1,6 @@
-import FileManagerPlugin from "filemanager-webpack-plugin";
 import { Configuration } from "webpack";
 import { generateWorkerCommonConfig } from "../common/webpack.worker.config";
 
-const ENTRY_FILE = "./index.js";
 const TMP_ENTRY_FILE = "./index.tmp.js";
 
 const generateWorkerFlareactConfig = (outputPath: string): Configuration  => {
@@ -13,20 +11,6 @@ const generateWorkerFlareactConfig = (outputPath: string): Configuration  => {
 
     // Set entry
     config.entry = TMP_ENTRY_FILE;
-
-    config.plugins?.push(
-        new FileManagerPlugin({
-            events: {
-                onStart: {
-                    copy: [{ source: ENTRY_FILE, destination: TMP_ENTRY_FILE }],
-                },
-                onEnd: {
-                    delete: [TMP_ENTRY_FILE],
-                },
-            },
-            runTasksInSeries: true,
-        })
-    );
 
     return config;
 }

--- a/src/configs/static-site/webpack.worker.config.ts
+++ b/src/configs/static-site/webpack.worker.config.ts
@@ -1,8 +1,6 @@
-import FileManagerPlugin from "filemanager-webpack-plugin";
 import { Configuration, DefinePlugin } from "webpack";
 import { generateWorkerCommonConfig } from "../common/webpack.worker.config";
 
-const ENTRY_FILE = "./src/index.js";
 const TMP_ENTRY_FILE = "./src/index.tmp.js";
 
 const generateWorkerStaticSiteConfig = (outputPath: string): Configuration  => {
@@ -13,20 +11,6 @@ const generateWorkerStaticSiteConfig = (outputPath: string): Configuration  => {
 
     // Set entry
     config.entry = TMP_ENTRY_FILE;
-
-    config.plugins?.push(
-        new FileManagerPlugin({
-            events: {
-                onStart: {
-                    copy: [{ source: ENTRY_FILE, destination: TMP_ENTRY_FILE }],
-                },
-                onEnd: {
-                    delete: [TMP_ENTRY_FILE],
-                },
-            },
-            runTasksInSeries: true,
-        })
-    );
 
     // Add define plugin
     config.plugins?.push(

--- a/test/ts/configs/flareact/webpack.worker.config.test.ts
+++ b/test/ts/configs/flareact/webpack.worker.config.test.ts
@@ -24,19 +24,4 @@ describe('flareact worker webpack config', () => {
         );
         expect(plugins).to.include.members(['VirtualModulesPlugin', 'LimitChunkCountPlugin']);
     });
-
-    it('should add file manager plugin with onStart copy and onEnd delete actions', () => {
-        const fileManagerPlugin: any = (workerFlareactConfig.plugins ?? []).filter(
-            (el: object) => el.constructor.name === "FileManagerPlugin"
-        )[0];
-
-        expect(fileManagerPlugin).not.to.be.undefined;
-        expect(fileManagerPlugin.options.runTasksInSeries).to.be.true;
-
-        const events = fileManagerPlugin.options.events;
-        expect(events.onStart.copy).not.to.be.undefined;
-        expect(events.onStart.copy).to.have.deep.members([{ source: './index.js', destination: './index.tmp.js' }]);
-        expect(events.onEnd.delete).not.to.be.undefined;
-        expect(events.onEnd.delete).to.have.deep.members(['./index.tmp.js']);
-    });
 });

--- a/test/ts/configs/static-site/webpack.worker.config.test.ts
+++ b/test/ts/configs/static-site/webpack.worker.config.test.ts
@@ -25,21 +25,6 @@ describe('static site worker webpack config', () => {
         expect(plugins).to.include.members(['VirtualModulesPlugin', 'LimitChunkCountPlugin']);
     });
 
-    it('should add file manager plugin with onStart copy and onEnd delete actions', () => {
-        const fileManagerPlugin: any = (workerStaticSiteConfig.plugins ?? []).filter(
-            (el: object) => el.constructor.name === "FileManagerPlugin"
-        )[0];
-
-        expect(fileManagerPlugin).not.to.be.undefined;
-        expect(fileManagerPlugin.options.runTasksInSeries).to.be.true;
-
-        const events = fileManagerPlugin.options.events;
-        expect(events.onStart.copy).not.to.be.undefined;
-        expect(events.onStart.copy).to.have.deep.members([{ source: './src/index.js', destination: './src/index.tmp.js' }]);
-        expect(events.onEnd.delete).not.to.be.undefined;
-        expect(events.onEnd.delete).to.have.deep.members(['./src/index.tmp.js']);
-    });
-
     it('should add DefinePlugin with PROJECT_TYPE definition', () => {
         const definePlugin: any = (workerStaticSiteConfig.plugins ?? []).filter(
             (el: object) => el.constructor.name === "DefinePlugin"


### PR DESCRIPTION
Removes the filemanager-webpack plugin and proposes using native compiler hooks to handle copying and removing the index.js file.