### PR TITLE
Fix version (v0.2.3) on package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azion-framework-adapter",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azion-framework-adapter",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.1031.0",


### PR DESCRIPTION
Since release of v0.2.3 the lock file was out of sync with package.json.