### PR TITLE
Change from execsync to spawn on build process

### DIFF
--- a/src/models/builders/nextjs-builder.ts
+++ b/src/models/builders/nextjs-builder.ts
@@ -133,7 +133,7 @@ class NextjsBuilder extends Builder {
         try {
             this.vercelService.createVercelProjectConfig();
 
-            this.vercelService.runVercelBuild();
+            await this.vercelService.runVercelBuild();
 
             const config = this.vercelService.loadVercelConfigs();
 


### PR DESCRIPTION
This "pr" proposes switching from execsync to "spawn" to improve user experience. With "spawn" the logs will appear in the terminal line by line as soon as they are generated by the vercel cli.